### PR TITLE
Fixed stickyHeader scrolling + added SuppressLint for unused Scaffold padding

### DIFF
--- a/app/src/main/java/com/example/traveladvisories/MainActivity.kt
+++ b/app/src/main/java/com/example/traveladvisories/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.traveladvisories
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -18,6 +19,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun TravelAdvisoriesApp() {
     Scaffold(topBar = {

--- a/feature/src/main/java/com/example/feature/countrylist/componenets/CountrySelectingList.kt
+++ b/feature/src/main/java/com/example/feature/countrylist/componenets/CountrySelectingList.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,7 +27,9 @@ fun CountryListList(
     ) {
         list.forEach { continent ->
             stickyHeader {
-                Text(text = continent.name, style = MaterialTheme.typography.h5,)
+                Surface(Modifier.fillParentMaxWidth()) {
+                    Text(text = continent.name, style = MaterialTheme.typography.h5,)
+                }
             }
 
             items(continent.countries) { item ->

--- a/feature/src/main/java/com/example/feature/countrylist/componenets/CountrySelectingList.kt
+++ b/feature/src/main/java/com/example/feature/countrylist/componenets/CountrySelectingList.kt
@@ -1,6 +1,7 @@
 package com.example.feature.countrylist.componenets
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -23,22 +23,31 @@ fun CountryListList(
     list: List<Continent>,
     onClick: ((Country) -> Unit)? = null
 ) {
-    LazyColumn(modifier = Modifier.padding(10.dp)
+    LazyColumn(
+        modifier = Modifier.padding(10.dp)
     ) {
         list.forEach { continent ->
             stickyHeader {
-                Surface(Modifier.fillParentMaxWidth()) {
-                    Text(text = continent.name, style = MaterialTheme.typography.h5,)
-                }
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color = MaterialTheme.colors.surface),
+                    text = continent.name,
+                    style = MaterialTheme.typography.h5
+                )
             }
 
             items(continent.countries) { item ->
-                Row(modifier = Modifier.clickable {
-                    onClick?.let { method ->
-                        method(item)
-                    }
-                }.fillMaxWidth()
-                    .padding(bottom = 10.dp)) {
+                Row(
+                    modifier = Modifier
+                        .clickable {
+                            onClick?.let { method ->
+                                method(item)
+                            }
+                        }
+                        .fillMaxWidth()
+                        .padding(bottom = 10.dp)
+                ) {
                     Text(item.countryName)
                 }
             }
@@ -49,7 +58,8 @@ fun CountryListList(
 @Preview
 @Composable
 fun CountryListListPreview() {
-    CountryListList(list = listOf(
+    CountryListList(
+        list = listOf(
             Continent(
                 name = "North America",
                 countries = listOf(Country(regionCode = "us"))


### PR DESCRIPTION
Hi,
I'm currently studying this app & exploring your architecture - it's really cool, and I can't wait to get into it more. I couldn't help but notice a very minor bug - the `stickyHeader` overlaps the list of countries when you scroll. By wrapping the continent Text in a Surface, it can cleanly give it a background w/Material defaults...here's an image of Before & After the fix:

https://drive.google.com/file/d/1QYd9nClASukgAOKMrrlyh-4q7x1MRIeZ/view?usp=sharing

Another solution is to add a background to the `stickyHeader`:

```
stickyHeader {
                Text(
                    modifier = Modifier
                        .fillMaxWidth()
                        .background(Color.White),
                    text = continent.name, style = MaterialTheme.typography.h5)
            }
```

I tested both ways on Android 12 + 13, but I'm still getting familiar with the app, so feel free to test some more. I'm happy to make any changes....