### PR TITLE
Adds Caribbean in Latin America section as countries of Caribbean is showing up in that section.

### DIFF
--- a/repositories/src/main/java/com/example/repositories/CountryListPushBasedRepository.kt
+++ b/repositories/src/main/java/com/example/repositories/CountryListPushBasedRepository.kt
@@ -38,7 +38,7 @@ class CountryListPushBasedRepository(private val travelAdvisoriesApi: ITravelAdv
                 val continents = listOf(
                     Pair("Africa", it.africa),
                     Pair("Asia", it.asia),
-                    Pair("Latin America", it.latam),
+                    Pair("Latin America and Caribbean", it.latam),
                     Pair("Oceania", it.oceania),
                     Pair("Europe", it.europe)
                 )


### PR DESCRIPTION
I was checking the App architecture and i notice that some countries that are not from Latin America are showing up in the "Latin America" Section. 
The Json that acts as a response from the API brings some countries from the Caribbean together with Latin America ones, I think that could be good if we can change the title to **Latin America and the Caribbean** and avoid that confusion in the UI.

Let me know if that makes sense!