### PR TITLE
Creates a base DisposableViewModel to automatically dispose all disposables.

### DIFF
--- a/viewmodels/src/main/java/com/example/viewmodels/CountryDetailsViewModel.kt
+++ b/viewmodels/src/main/java/com/example/viewmodels/CountryDetailsViewModel.kt
@@ -1,14 +1,12 @@
 package com.example.viewmodels
 
-import androidx.lifecycle.ViewModel
 import com.example.domainmodels.CountryDetails
 import com.example.errors.CountryDetailsError
 import com.example.logic.CountryDetailsLogic
 import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 
-class CountryDetailsViewModel(private val logic: CountryDetailsLogic, regionCode: String) : ViewModel() {
+class CountryDetailsViewModel(private val logic: CountryDetailsLogic, regionCode: String) : DisposerViewModel() {
     sealed class UiState {
         object Initial : UiState()
         object Loading : UiState()
@@ -19,8 +17,6 @@ class CountryDetailsViewModel(private val logic: CountryDetailsLogic, regionCode
     private var _state: BehaviorSubject<UiState> = BehaviorSubject.createDefault(
         UiState.Initial)
     val state: Observable<UiState> = _state
-
-    private var disposables = CompositeDisposable()
 
     init {
         onPageLoaded(regionCode)
@@ -38,10 +34,5 @@ class CountryDetailsViewModel(private val logic: CountryDetailsLogic, regionCode
                     _state.onNext(UiState.Error(error as CountryDetailsError))
                 })
         )
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        disposables.dispose()
     }
 }

--- a/viewmodels/src/main/java/com/example/viewmodels/CountryDetailsViewModel.kt
+++ b/viewmodels/src/main/java/com/example/viewmodels/CountryDetailsViewModel.kt
@@ -6,7 +6,7 @@ import com.example.logic.CountryDetailsLogic
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 
-class CountryDetailsViewModel(private val logic: CountryDetailsLogic, regionCode: String) : DisposerViewModel() {
+class CountryDetailsViewModel(private val logic: CountryDetailsLogic, regionCode: String) : DisposableViewModel() {
     sealed class UiState {
         object Initial : UiState()
         object Loading : UiState()

--- a/viewmodels/src/main/java/com/example/viewmodels/CountryListViewModel.kt
+++ b/viewmodels/src/main/java/com/example/viewmodels/CountryListViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.viewmodels
 
-import androidx.lifecycle.ViewModel
 import com.example.domainmodels.Continent
 import com.example.domainmodels.Country
 import com.example.domainmodels.ServerStatus
@@ -8,10 +7,9 @@ import com.example.errors.CountryListError
 import com.example.logic.CountryListLogic
 import com.example.logic.ServerStatusLogic
 import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 
-class CountryListViewModel(val logic: CountryListLogic, val serverStatusLogic: ServerStatusLogic) : ViewModel() {
+class CountryListViewModel(private val logic: CountryListLogic, private val serverStatusLogic: ServerStatusLogic) : DisposerViewModel() {
     data class UiState(
         val continents: List<Continent> = emptyList(),
         val isLoading: Boolean = false,
@@ -23,7 +21,6 @@ class CountryListViewModel(val logic: CountryListLogic, val serverStatusLogic: S
 
     private val _state: BehaviorSubject<UiState> = BehaviorSubject.createDefault(UiState())
     val state: Observable<UiState> = _state
-    private val disposables = CompositeDisposable()
 
     init {
         // https://stackoverflow.com/questions/73305899/why-launchedeffect-call-second-time-when-i-navigate-back

--- a/viewmodels/src/main/java/com/example/viewmodels/CountryListViewModel.kt
+++ b/viewmodels/src/main/java/com/example/viewmodels/CountryListViewModel.kt
@@ -9,7 +9,7 @@ import com.example.logic.ServerStatusLogic
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 
-class CountryListViewModel(private val logic: CountryListLogic, private val serverStatusLogic: ServerStatusLogic) : DisposerViewModel() {
+class CountryListViewModel(private val logic: CountryListLogic, private val serverStatusLogic: ServerStatusLogic) : DisposableViewModel() {
     data class UiState(
         val continents: List<Continent> = emptyList(),
         val isLoading: Boolean = false,

--- a/viewmodels/src/main/java/com/example/viewmodels/DisposableViewModel.kt
+++ b/viewmodels/src/main/java/com/example/viewmodels/DisposableViewModel.kt
@@ -3,7 +3,7 @@ package com.example.viewmodels
 import androidx.lifecycle.ViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 
-open class DisposerViewModel : ViewModel() {
+open class DisposableViewModel : ViewModel() {
 
     protected val disposables = CompositeDisposable()
     override fun onCleared() {

--- a/viewmodels/src/main/java/com/example/viewmodels/DisposerViewModel.kt
+++ b/viewmodels/src/main/java/com/example/viewmodels/DisposerViewModel.kt
@@ -1,0 +1,13 @@
+package com.example.viewmodels
+
+import androidx.lifecycle.ViewModel
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+
+open class DisposerViewModel : ViewModel() {
+
+    protected val disposables = CompositeDisposable()
+    override fun onCleared() {
+        super.onCleared()
+        disposables.dispose()
+    }
+}


### PR DESCRIPTION
There are some ViewModels in DemoApp's architecture that directly disposes of all disposables in onCleared. 
I think we can have the benefits of having a base DisposableViewModel that can handle that even if we forgot about that. And helps to write less code. 