### PR TITLE
Makes uptime property in ServerStatusDTO optional to prevent crash

### DIFF
--- a/interfaces/src/main/java/com/example/dtos/ServerStatusDTO.kt
+++ b/interfaces/src/main/java/com/example/dtos/ServerStatusDTO.kt
@@ -8,7 +8,7 @@ data class ServerStatusDTO(
     @Json(name = "ok")
     val ok: Boolean,
     @Json(name = "uptime")
-    val uptime: Float,
+    val uptime: Float?,
 ) {
     companion object {
         val EMPTY = ServerStatusDTO(ok = false, uptime = 0f)


### PR DESCRIPTION
The server status [API ](https://status.scruff.com/index.json) sometimes does not return the uptime property, which leads to a crash. Making uptime optional can prevent that crash from occurring.